### PR TITLE
Adds call-out support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ pulldown-cmark = { version = "0.8", default-features = false, features = ["simd"
 ammonia = "3"
 url = "2.2.1"
 emojis = "0.1.2"
+regex = "1"
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 indoc = "1.0.2"


### PR DESCRIPTION
* Use a {% <type> <optional title? %} ... {% end %} syntax
* Refactors the parser to allow peeking